### PR TITLE
Allow for centralised config in Victoria cloud backend

### DIFF
--- a/example_config.yaml
+++ b/example_config.yaml
@@ -1,8 +1,8 @@
 access:
-  access_token: insert-token
-  organisation: glasswall
-  project: Glasswall Cloud
-  email: apotter-dixon@glasswallsolutions.com
+  access_token: <encrypted data>
+  organisation: <encrypted data>
+  project: <encrypted data>
+  email: <encrypted data>
 
 deployments:
   - stage: deploy_init_infrastructure

--- a/tests/rebuilder/test_cli_calls.py
+++ b/tests/rebuilder/test_cli_calls.py
@@ -1,6 +1,4 @@
-from click.testing import CliRunner
 import pytest
-from victoria_rebuilder.cli import rebuilder
 from conftest import create_mock_client
 
 

--- a/tests/rebuilder/test_client.py
+++ b/tests/rebuilder/test_client.py
@@ -1,6 +1,3 @@
-import pytest
-
-
 def test_api_release_client_is_setup(mock_client):
     assert mock_client.release_client is not None
 
@@ -21,6 +18,5 @@ def test_get_latest_successful_release_pent_qa(mock_client):
 
 def test_get_release_rejected_status(mock_client):
 
-    release_status =  mock_client.get_release_status("Test_Project", 321, 123)
-    assert release_status == "rejected" 
-   
+    release_status = mock_client.get_release_status("Test_Project", 321, 123)
+    assert release_status == "rejected"

--- a/tests/rebuilder/test_rebuild.py
+++ b/tests/rebuilder/test_rebuild.py
@@ -1,7 +1,7 @@
-import pytest
 import os
+
+import pytest
 from munch import munchify
-from unittest.mock import patch
 
 
 def test_rebuild(mock_rebuild):
@@ -13,8 +13,7 @@ def test_creates_save_file(mock_rebuild):
     assert os.path.exists("rebuild")
 
 
-
-def test_runs_if_inprogress(mock_rebuild ):
+def test_runs_if_inprogress(mock_rebuild):
     release = {
         "name": "Platform.Engine",
         "complete": False,
@@ -23,9 +22,8 @@ def test_runs_if_inprogress(mock_rebuild ):
     }
     releases = [munchify(release)]
     releases = mock_rebuild.run_releases(releases, "qa", "pent")
-    
-    assert releases
 
+    assert releases
 
 
 def test_wait_updates_release_complete(mock_rebuild):
@@ -38,7 +36,7 @@ def test_wait_updates_release_complete(mock_rebuild):
     releases = [munchify(release)]
     releases = mock_rebuild.wait_to_complete(releases, 1)
 
-    assert releases[0].complete == True
+    assert releases[0].complete is True
 
 
 def test_run_releases_removes_unfound(mock_rebuild):
@@ -52,6 +50,7 @@ def test_run_releases_removes_unfound(mock_rebuild):
 
     assert not releases
 
+
 def test_ask_failed_release_re_run_true(monkeypatch, mock_rebuild):
     release = {
         "release_id": 321,
@@ -59,13 +58,14 @@ def test_ask_failed_release_re_run_true(monkeypatch, mock_rebuild):
         "name": "Test_failed_release",
         "complete": False
     }
-    release = munchify(release)  
-    
+    release = munchify(release)
+
     monkeypatch.setattr('builtins.input', lambda: "Y")
 
     run_again = mock_rebuild._re_run_failed_release(release.release_id, release.environment_id, release.name)
-    
+
     assert run_again
+
 
 def test_ask_failed_release_re_run_false(monkeypatch, mock_rebuild):
     release = {
@@ -74,13 +74,14 @@ def test_ask_failed_release_re_run_false(monkeypatch, mock_rebuild):
         "name": "Test_failed_release",
         "complete": False
     }
-    release = munchify(release)  
-    
+    release = munchify(release)
+
     monkeypatch.setattr('builtins.input', lambda: "N")
 
     run_again = mock_rebuild._re_run_failed_release(release.release_id, release.environment_id, release.name)
-    
+
     assert not run_again
+
 
 def test_wait_failed_release_not_continue(monkeypatch, mock_rebuild):
     release = {
@@ -92,40 +93,42 @@ def test_wait_failed_release_not_continue(monkeypatch, mock_rebuild):
     releases = [munchify(release)]
     monkeypatch.setattr('builtins.input', lambda: "n")
     releases = mock_rebuild.wait_to_complete(releases, 1)
-    
 
-    assert releases[0].complete == True
+    assert releases[0].complete is True
+
 
 def test_query_yes_no_invalid_default(monkeypatch, mock_rebuild):
     with pytest.raises(ValueError):
         mock_rebuild._query_yes_no("What colour is the sky?", "blue")
 
+
 def test_query_yes_no_returns_true(monkeypatch, mock_rebuild):
     monkeypatch.setattr('builtins.input', lambda: "Y")
     answer = mock_rebuild._query_yes_no("What colour is the sky?")
 
-    assert answer 
+    assert answer
+
 
 def test_query_yes_no_returns_false(monkeypatch, mock_rebuild):
     monkeypatch.setattr('builtins.input', lambda: "n")
     answer = mock_rebuild._query_yes_no("What colour is the sky?")
 
-    assert not answer 
+    assert not answer
+
 
 def test_query_yes_no_valid_output(capsys, monkeypatch, mock_rebuild):
     monkeypatch.setattr('builtins.input', lambda: "y")
-    
+
     answer = mock_rebuild._query_yes_no("What colour is the sky?")
     captured = capsys.readouterr()
     assert captured.out == "What colour is the sky? [Y/n] "
 
-def test_query_yes_no_invalid_output( monkeypatch, mock_rebuild):
-    
-    responses = iter(['dog','Y'])
-    monkeypatch.setattr('builtins.input', lambda : next(responses))
+
+def test_query_yes_no_invalid_output(monkeypatch, mock_rebuild):
+    responses = iter(['dog', 'Y'])
+    monkeypatch.setattr('builtins.input', lambda: next(responses))
     answer = mock_rebuild._query_yes_no("What colour is the sky?")
     assert answer
-     
 
 
 def test_cleanup(mock_rebuild):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,21 +1,16 @@
-import click
 from click.testing import CliRunner
+
 from victoria_rebuilder import cli
 
-def test_rebuild_extra_argument_fail():
-   
 
+def test_rebuild_extra_argument_fail():
     runner = CliRunner()
     result = runner.invoke(cli.rebuild, ['qa', 'pent'])
     assert result.exit_code == 2
 
 
-
 def test_rebuild():
-   
-
     runner = CliRunner()
     result = runner.invoke(cli.rebuild, ['qa'])
     print(result)
     assert result.exit_code == 1
-

--- a/victoria_rebuilder/client.py
+++ b/victoria_rebuilder/client.py
@@ -7,14 +7,13 @@ Parameters:
 
 """
 
+import logging
 from typing import Tuple, Union
 
 from azure.devops.connection import Connection
 from msrest.authentication import BasicAuthentication
 
 from victoria_rebuilder.config import AccessConfig
-import logging
-import sys
 
 
 class DevOpsClient:
@@ -24,7 +23,7 @@ class DevOpsClient:
         self._connect()
 
     def get_release_status(self, release_id: str, environment_id: int,
-                            name: str) -> bool:
+                           name: str) -> bool:
         """
         Retrieves the current release status of a particular release and environment.
 
@@ -92,16 +91,16 @@ class DevOpsClient:
                     result.environments, target_env)
 
                 for environment in result.environments:
-                    
+
                     if environment.name == from_env and (
                             environment.status == "succeeded"
                             or environment.status == "partiallySucceeded"
                             or environment.status == "queued"
-                            or environment.status == "inProgress" ):
+                            or environment.status == "inProgress"):
                         logging.info(
                             f"Found environment for {name} with id: {environment.id} "
                         )
-                        
+
                         return release.id, target_env_id
 
         return None, None
@@ -131,7 +130,7 @@ class DevOpsClient:
 
     def run_release(self, release_id: int, environment_id: int, release_name: str) -> None:
         """
-        Runs the latest succeeded or partically succeeded pipeline associated
+        Runs the latest succeeded or partially succeeded pipeline associated
         with the object.
 
         Arguments:
@@ -151,12 +150,13 @@ class DevOpsClient:
                 "status": "inProgress"
             }
             self.release_client.update_release_environment(start_values,
-                                                            self.access_cfg.project,
-                                                            release_id,
-                                                            environment_id)
+                                                           self.access_cfg.project,
+                                                           release_id,
+                                                           environment_id)
             logging.info(f"Running release {release_id} for {release_name}.")
         else:
-            logging.info(f"Release {release_id} for {release_name} is currently {release_environment.status} so not starting for this run.")
+            logging.info(
+                f"Release {release_id} for {release_name} is currently {release_environment.status} so not starting for this run.")
 
     def _connect(self):
         """


### PR DESCRIPTION
This PR does the following:
- Allows centralised config in Victoria cloud backend
- Code cleanup (unused imports, code formatting, code cleanup, etc).

I gathered all the changes in a single commit.

